### PR TITLE
Added concepts

### DIFF
--- a/content/concepts/architecture.md
+++ b/content/concepts/architecture.md
@@ -39,10 +39,10 @@ Cleanup runs through Kubernetes garbage collection rather than through the opera
 
 | Rendered resource | Owner set by `TemplateInstance` | Owner set by `ClusterTemplateInstance` |
 | --- | --- | --- |
-| Namespaced | The instance | The instance |
+| Namespace-scoped | The instance | The instance |
 | Cluster-scoped | The `Template` | The instance |
 
-A namespaced resource cannot own a cluster-scoped one, so a `TemplateInstance` that renders something cluster-scoped, a `ClusterRole` for example, falls back to making the `Template` the owner. The resource then survives deletion of the instance and is collected only when the template itself is deleted. This is deliberate, as the alternative would be a resource nothing ever cleans up.
+A namespace-scoped resource cannot own a cluster-scoped one, so a `TemplateInstance` that renders something cluster-scoped, a `ClusterRole` for example, falls back to making the `Template` the owner. The resource then survives deletion of the instance and is collected only when the template itself is deleted. This is deliberate, as the alternative would be a resource nothing ever cleans up.
 
 `ClusterTemplateInstance` cannot rely on garbage collection alone, because it writes into namespaces it does not own. It records every namespace it has deployed to in `status.deployedNamespaces` and compares that list against the current selector match on each reconcile, removing resources from namespaces that no longer match.
 

--- a/content/concepts/architecture.md
+++ b/content/concepts/architecture.md
@@ -1,11 +1,56 @@
 # Architecture
 
-The Template Operator is a comprehensive system designed to manage multi-tenancy in Kubernetes environments. Following is the architecture of the Template Operator:
+Template Operator distributes Kubernetes resources across namespaces. A cluster-scoped `Template` holds the resource definitions, and an instance resource decides where those definitions are applied: a `TemplateInstance` targets the single namespace it lives in, while a `ClusterTemplateInstance` targets every namespace matching a label selector.
 
-Template Operator consists of multiple controllers and components that work together to provide the functionality of the system. The following is a list of the components that make up the Template Operator system:
+## API groups
 
-| Name | Type | Description |
-|------|------|-------------|
-| Template Operator Manager | Deployment | The Template Operator Manager manages 3 different CRDs in one controller; Template, Template Instance and Cluster Template Instance. |
-| Template Operator Old Manager | Deployment | The Template Operator Old Manager manages older/legacy CRDs of the older version of operator, which were part of Multi Tenant Operator. It serves to handle older versions if needed during migration. |
-| Webhook | Deployment | The Webhook is responsible for managing webhook requests from Custom Resources. |
+The operator serves two API groups at the same time.
+
+| Group | Kinds | Status |
+| --- | --- | --- |
+| `templates.stakater.com/v1alpha1` | `Template`, `TemplateInstance`, `ClusterTemplateInstance` | Current. Use this for new work. |
+| `tenantoperator.stakater.com/v1alpha1` | `Template`, `TemplateInstance`, `TemplateGroupInstance` | Legacy, from when templating was part of Multi Tenant Operator. Served so existing resources keep working during migration. |
+
+The legacy `TemplateGroupInstance` is the predecessor of `ClusterTemplateInstance`.
+
+## Components
+
+The operator ships as three Deployments. The two manager Deployments run the same operator image once per controller as separate containers, and an environment variable selects which controller each container starts. Running the controllers in separate containers keeps one controller's failures from stalling the others.
+
+| Deployment | Containers | Description |
+| --- | --- | --- |
+| `manager` | `template-controller`, `templateinstance-controller`, `clustertemplateinstance-controller` | Reconciles the current `templates.stakater.com/v1alpha1` resources. |
+| `old-manager` | `template-controller`, `templateinstance-controller`, `templategroupinstance-controller` | Reconciles the legacy `tenantoperator.stakater.com/v1alpha1` resources. Each container additionally sets `OLD_TEMPLATES_OPERATOR=true`. |
+| `webhook` | `webhook-manager` | Serves the validating admission webhooks for both API groups. |
+
+Each controller container is enabled by its own variable: `TEMPLATE_CONTROLLER`, `TEMPLATEINSTANCE_CONTROLLER`, `CLUSTERTEMPLATEINSTANCE_CONTROLLER` and `TEMPLATEGROUPINSTANCE_CONTROLLER`. Setting `ENABLE_ALL_CONTROLLERS` starts all of them in a single process instead.
+
+## How resources are applied
+
+When an instance is reconciled, the controller reads the referenced `Template`, resolves parameters against the target namespace, renders the resources, and applies them. Rendering depends on which field the `Template` uses: `manifests` are applied close to as written, `helm` is rendered through `helm template`, `gotemplate` is executed as a Go template, and `resourceMappings` copies existing Secrets and ConfigMaps rather than creating new definitions.
+
+The controllers watch more than their own resource. Both instance controllers watch `Template` so that a template edit re-reconciles the instances referring to it, and they watch Secrets and ConfigMaps so that a change to a mapped source resource propagates to its copies.
+
+To avoid reacting to updates that change nothing, the instance status stores a hash of the last rendered output. `TemplateInstance` keeps a single `templateHash`, and `ClusterTemplateInstance` keeps `templateManifestsHash` and `templateResourceMappingHash` separately, so an edit to a template's manifests does not force resource mappings to be redistributed.
+
+## Ownership and cleanup
+
+Cleanup runs through Kubernetes garbage collection rather than through the operator, which is why the operator's own finalizers, `templates.stakater.com/template` and `templates.stakater.com/ti`, delete nothing themselves. Each rendered resource is given a controller owner reference, and which owner it gets depends on the scope of both the resource and the instance:
+
+| Rendered resource | Owner set by `TemplateInstance` | Owner set by `ClusterTemplateInstance` |
+| --- | --- | --- |
+| Namespaced | The instance | The instance |
+| Cluster-scoped | The `Template` | The instance |
+
+A namespaced resource cannot own a cluster-scoped one, so a `TemplateInstance` that renders something cluster-scoped, a `ClusterRole` for example, falls back to making the `Template` the owner. The resource then survives deletion of the instance and is collected only when the template itself is deleted. This is deliberate, as the alternative would be a resource nothing ever cleans up.
+
+`ClusterTemplateInstance` cannot rely on garbage collection alone, because it writes into namespaces it does not own. It records every namespace it has deployed to in `status.deployedNamespaces` and compares that list against the current selector match on each reconcile, removing resources from namespaces that no longer match.
+
+## Admission validation
+
+The webhook Deployment registers validating webhooks for all six kinds across both API groups. Two rules matter in day to day use:
+
+- Creating or updating a `TemplateInstance` or `ClusterTemplateInstance` is rejected if the referenced `Template` does not exist.
+- Deleting a `Template` is rejected while any instance still references it. The error lists the referencing resources.
+
+Admission validation is controlled by `ENABLE_WEBHOOKS` and `ENABLE_ADMISSION_WEBHOOKS` on the webhook Deployment.

--- a/content/concepts/templates/cluster-template-instance.md
+++ b/content/concepts/templates/cluster-template-instance.md
@@ -71,3 +71,10 @@ Overall progress is reported through `status.conditions` rather than a single st
 Use a `TemplateInstance` when a namespace owner should decide what lands in their own namespace, and the set of namespaces is not the point. Use a `ClusterTemplateInstance` when a platform team is enforcing something across a group of namespaces defined by labels, particularly when namespaces are created and removed regularly and each one should pick up the template without anyone acting.
 
 The two can be used against the same template. A template is only a definition, and nothing stops one being consumed both ways.
+
+## Related guides
+
+- [Sync Resources Deployed by ClusterTemplateInstance](../../guides/templates/resource-sync-by-tgi.md)
+- [Propagate Secrets from Parent to Descendant namespaces](../../guides/templates/copying-resources.md)
+- [Deploying Private Helm Chart to Multiple Namespaces](../../guides/templates/deploying-private-helm-charts.md)
+- [Distributing Secrets Using Sealed Secrets Template](../../guides/templates/distributing-secrets-using-sealed-secret-template.md)

--- a/content/concepts/templates/cluster-template-instance.md
+++ b/content/concepts/templates/cluster-template-instance.md
@@ -56,7 +56,7 @@ Cleanup of namespaces that stopped matching runs regardless of the `sync` settin
 
 ## Ownership and deletion
 
-Because a `ClusterTemplateInstance` is itself cluster-scoped, it can own everything it renders, both namespaced and cluster-scoped resources. Deleting the instance removes all of them through garbage collection. This is the one respect in which it is simpler than `TemplateInstance`, where cluster-scoped resources have to fall back to the `Template` as owner.
+Because a `ClusterTemplateInstance` is itself cluster-scoped, it can own everything it renders, both namespace-scoped and cluster-scoped resources. Deleting the instance removes all of them through garbage collection. This is the one respect in which it is simpler than `TemplateInstance`, where cluster-scoped resources have to fall back to the `Template` as owner.
 
 Deleting the referenced `Template` is rejected by the admission webhook while the instance still exists.
 

--- a/content/concepts/templates/cluster-template-instance.md
+++ b/content/concepts/templates/cluster-template-instance.md
@@ -1,6 +1,6 @@
 # ClusterTemplateInstance
 
-Cluster scoped resource:
+A `ClusterTemplateInstance` applies a [Template](template.md) to every namespace matching a label selector. It is cluster-scoped, and it exists for the case a [TemplateInstance](template-instance.md) cannot cover: distributing one set of resources across a group of namespaces whose membership changes over time.
 
 ```yaml
 apiVersion: templates.stakater.com/v1alpha1
@@ -22,4 +22,52 @@ spec:
       value: "172.17.0.0/16"
 ```
 
-ClusterTemplateInstance distributes a template across multiple namespaces which are selected by labelSelector.
+`spec.selector` is a standard Kubernetes label selector evaluated against namespaces, so both `matchLabels` and `matchExpressions` work. Membership is re-evaluated on every reconcile rather than resolved once at creation, which is what makes the resource useful for a set that grows.
+
+For the complete field listing, see the [API Reference](../../reference/api.md).
+
+## Rendering per namespace
+
+The template is rendered separately for each matching namespace, not once and copied. Parameters that read namespace metadata therefore resolve to different values in each one. A template referencing `${NAMESPACE}` or `${namespace.metadata.labels.environment}` produces genuinely different output per target, which is usually the reason to use a selector rather than a set of individual instances.
+
+See [Parameters](template.md#parameters) for the values available.
+
+## How namespaces are added and removed
+
+On each reconcile the controller compares the namespaces currently matching the selector against `status.deployedNamespaces`, the record of where it has already deployed, and sorts them into three groups.
+
+| Group | Action |
+| --- | --- |
+| Matching, not yet deployed to, or previously failed | The template is rendered and applied |
+| Matching and already deployed successfully | Re-rendered only when `sync` is true |
+| Deployed to previously, no longer matching | The resources are removed from that namespace |
+
+The third row is the part worth internalizing. Removing a label from a namespace, or narrowing the selector, is an instruction to delete the resources there. The operator cannot lean on garbage collection for this, since the namespaces are not its own, so it tracks them explicitly and cleans up on the next reconcile.
+
+Namespaces that have been deleted outright are skipped rather than cleaned up, as there is nothing left to remove.
+
+## Sync
+
+`spec.sync` controls whether namespaces that already have the template are refreshed when the template changes.
+
+New matching namespaces are always deployed to, with sync off or on. What sync adds is propagation of template edits to namespaces already covered. With `sync` false, each namespace receives the template as it looked when that namespace first matched, so a long-lived instance can end up with different content in different namespaces.
+
+Cleanup of namespaces that stopped matching runs regardless of the `sync` setting.
+
+## Ownership and deletion
+
+Because a `ClusterTemplateInstance` is itself cluster-scoped, it can own everything it renders, both namespaced and cluster-scoped resources. Deleting the instance removes all of them through garbage collection. This is the one respect in which it is simpler than `TemplateInstance`, where cluster-scoped resources have to fall back to the `Template` as owner.
+
+Deleting the referenced `Template` is rejected by the admission webhook while the instance still exists.
+
+## Status
+
+`status.deployedNamespaces` maps each namespace to its deployment state, and `status.namespaceCount` gives the number of namespaces currently matched. Mapped resources are tracked per namespace in `status.mappedSecrets` and `status.mappedConfigmaps`, so a mapping that fails in one namespace is visible without hiding successful copies elsewhere.
+
+Overall progress is reported through `status.conditions` rather than a single status string, which is the main way the resource differs from `TemplateInstance`. Two hashes, `templateManifestsHash` and `templateResourceMappingHash`, are stored separately so that editing a template's manifests does not trigger a redistribution of its resource mappings.
+
+## Choosing between the two
+
+Use a `TemplateInstance` when a namespace owner should decide what lands in their own namespace, and the set of namespaces is not the point. Use a `ClusterTemplateInstance` when a platform team is enforcing something across a group of namespaces defined by labels, particularly when namespaces are created and removed regularly and each one should pick up the template without anyone acting.
+
+The two can be used against the same template. A template is only a definition, and nothing stops one being consumed both ways.

--- a/content/concepts/templates/template-instance.md
+++ b/content/concepts/templates/template-instance.md
@@ -57,3 +57,8 @@ The remaining fields are working state rather than something to act on. `templat
 | `ErrorMappingResources` | A Secret or ConfigMap named in `resourceMappings` could not be read or copied |
 
 Two related errors surface at admission time rather than in status, because the webhook rejects the request outright: referencing a template that does not exist when creating or updating an instance, and deleting a `Template` while any instance still references it.
+
+## Related guides
+
+- [Distributing Resources in Namespaces](../../guides/templates/deploying-templates.md)
+- [Copying Secrets and ConfigMaps across Tenant Namespaces via TGI](../../guides/templates/copying-resources-2.md)

--- a/content/concepts/templates/template-instance.md
+++ b/content/concepts/templates/template-instance.md
@@ -16,7 +16,7 @@ spec:
       value: "172.17.0.0/16"
 ```
 
-`spec.template` names a cluster-scoped `Template`. There is no namespace component, since templates are not namespaced. The API treats this field as immutable: to point a workload at a different template, delete the instance and create a new one rather than editing it in place.
+`spec.template` names a cluster-scoped `Template`. There is no namespace component, since templates are cluster-scoped. The API treats this field as immutable: to point a workload at a different template, delete the instance and create a new one rather than editing it in place.
 
 Parameters listed under `spec.parameters` override the defaults declared on the template. The template must declare every parameter the instance sets, otherwise the deployment fails. See [Parameters](template.md#parameters) for resolution order and the predefined values available.
 
@@ -36,9 +36,9 @@ This applies to resource mappings too. The controller does watch the source Secr
 
 ## Ownership and deletion
 
-Namespaced resources rendered by a `TemplateInstance` are given the instance as their controller owner, so deleting the instance removes them through ordinary garbage collection.
+Namespace-scoped resources rendered by a `TemplateInstance` are given the instance as their controller owner, so deleting the instance removes them through ordinary garbage collection.
 
-Cluster-scoped resources are the exception. A namespaced object cannot own a cluster-scoped one, so those are owned by the `Template` instead. A `ClusterRole` created through a `TemplateInstance` therefore outlives the instance and is removed only when the template is deleted.
+Cluster-scoped resources are the exception. A namespace-scoped object cannot own a cluster-scoped one, so those are owned by the `Template` instead. A `ClusterRole` created through a `TemplateInstance` therefore outlives the instance and is removed only when the template is deleted.
 
 ## Status
 

--- a/content/concepts/templates/template-instance.md
+++ b/content/concepts/templates/template-instance.md
@@ -1,6 +1,6 @@
 # TemplateInstance
 
-Namespace scoped resource:
+A `TemplateInstance` applies a [Template](template.md) to the namespace it lives in. It is the namespace-scoped counterpart of [ClusterTemplateInstance](cluster-template-instance.md), and it is the resource to reach for when a team owns a namespace and wants a standard set of resources in it.
 
 ```yaml
 apiVersion: templates.stakater.com/v1alpha1
@@ -16,5 +16,44 @@ spec:
       value: "172.17.0.0/16"
 ```
 
-TemplateInstance are used to keep track of resources created from Templates, which are being instantiated inside a Namespace.
-Generally, a TemplateInstance is created from a Template and then the TemplateInstances will not be updated when the Template changes later on. To change this behavior, it is possible to set `spec.sync: true` in a TemplateInstance. Setting this option, means to keep this TemplateInstance in sync with the underlying template (similar to Helm upgrade).
+`spec.template` names a cluster-scoped `Template`. There is no namespace component, since templates are not namespaced. The API treats this field as immutable: to point a workload at a different template, delete the instance and create a new one rather than editing it in place.
+
+Parameters listed under `spec.parameters` override the defaults declared on the template. The template must declare every parameter the instance sets, otherwise the deployment fails. See [Parameters](template.md#parameters) for resolution order and the predefined values available.
+
+For the complete field listing, see the [API Reference](../../reference/api.md).
+
+## Sync
+
+`spec.sync` decides whether the instance tracks its template after the first deployment.
+
+With `sync` left at its default of false, the template is rendered once. Once the instance reports a status, the controller returns early on every later reconcile, so subsequent edits to the template are not picked up. The deployed resources stay as they were first rendered.
+
+With `sync: true`, the instance is reconciled whenever its template changes, and the rendered resources are brought back in line. This is comparable to running `helm upgrade` on every chart change.
+
+Switching `sync` on later takes effect immediately. The edit triggers a reconcile, the instance is rendered again, and anything that drifted while sync was off is overwritten at that point rather than at the next template change.
+
+This applies to resource mappings too. The controller does watch the source Secrets and ConfigMaps and will wake up when they change, but the sync check runs before the mapping work, so a non-syncing instance keeps whatever it copied the first time. Use `sync: true` on any instance whose mapped resources are expected to track their source.
+
+## Ownership and deletion
+
+Namespaced resources rendered by a `TemplateInstance` are given the instance as their controller owner, so deleting the instance removes them through ordinary garbage collection.
+
+Cluster-scoped resources are the exception. A namespaced object cannot own a cluster-scoped one, so those are owned by the `Template` instead. A `ClusterRole` created through a `TemplateInstance` therefore outlives the instance and is removed only when the template is deleted.
+
+## Status
+
+`status.status` reports `Deployed`, `Failed`, or an empty value while the instance is still pending. On failure, `status.reason` carries a short CamelCase code and `status.message` the detail.
+
+The remaining fields are working state rather than something to act on. `templateHash` and `templateManifests` record what was last rendered, which is how the controller ignores template updates that change nothing. `mappedSecrets` and `mappedConfigmaps` track each copied resource separately, so one failed mapping is visible without obscuring the others.
+
+## Common failures
+
+| `reason` | Cause |
+| --- | --- |
+| `TemplateNotFound` | `spec.template` names a template that does not exist |
+| `ErrorReplaceParameters` | A parameter could not be resolved, or a value failed the template's `validation` pattern |
+| `ErrorRenderingGoTemplate` | The `gotemplate` body failed to execute |
+| `ErrorParsingGoTemplate` | The template rendered, but the output was not valid Kubernetes YAML |
+| `ErrorMappingResources` | A Secret or ConfigMap named in `resourceMappings` could not be read or copied |
+
+Two related errors surface at admission time rather than in status, because the webhook rejects the request outright: referencing a template that does not exist when creating or updating an instance, and deleting a `Template` while any instance still references it.

--- a/content/concepts/templates/template.md
+++ b/content/concepts/templates/template.md
@@ -1,30 +1,28 @@
 # Template
 
-Templates are used to initialize Namespaces, share common resources across namespaces, and map secrets/ConfigMaps from one namespace to other namespaces.
+A `Template` holds the resource definitions you want to distribute. It is cluster-scoped and inert on its own: nothing is created until a [TemplateInstance](template-instance.md) or [ClusterTemplateInstance](cluster-template-instance.md) references it and supplies a target.
 
-They can contain pre-defined parameters such as `${namespace}`/`${tenant}`.
+Typical uses are initializing new namespaces with a baseline set of resources, sharing common resources across namespaces, and copying Secrets or ConfigMaps from one namespace into others.
 
-Also, you can define custom variables in `Template`, `TemplateInstance` and `ClusterTemplateInstance`. The parameters defined in `Templates` are overwritten the values defined in `TemplateInstance` and `ClusterTemplateInstance`.
+!!! note
+    `resources` and `parameters` are top-level fields on a `Template`, siblings of `metadata`, not children of `spec`. The `spec` field exists but carries nothing.
 
-## Specification
+For the complete field listing, see the [API Reference](../../reference/api.md).
 
-`Template` Custom Resource (CR) supports four key methods for defining and managing resources: `manifests`, `helm`, `gotemplate`, and `resource mapping`. Let’s dive into each method, their differences, and their use cases:
+## Resource sources
 
-### 1. Manifests
+A `Template` supplies its definitions through one of four fields: `manifests`, `helm`, `gotemplate`, or `resourceMappings`. They differ in how much templating logic they support and whether they create resources or copy existing ones.
 
-This approach uses raw Kubernetes manifests (YAML files) that specify resources directly in the template.
+| Field | Creates | Best for |
+| --- | --- | --- |
+| `manifests` | New resources from inline YAML | Static or lightly parameterized resources |
+| `helm` | New resources rendered from a chart | Interdependent resources, or packaging that already exists as a chart |
+| `gotemplate` | New resources from an inline Go template | Dynamic output where a full chart is more than you need |
+| `resourceMappings` | Copies of existing Secrets and ConfigMaps | Sharing a resource that is already maintained elsewhere |
 
-#### How It Works
+### Manifests
 
-* The template includes the actual YAML specifications of resources like `Deployment`, `Service`, `ConfigMap`, etc.
-* These manifests are applied as-is or with minor parameter substitutions (e.g., dynamically populated `{tenant}` and `{namespace}` variables wherever added or user defined parameters).
-
-#### Use Cases
-
-* Best for straightforward and simple resources where you don't need advanced templating logic or dependency management.
-* Ideal when the resource definitions are static or have minimal customization needs.
-
-#### Example
+Raw Kubernetes manifests written inline. They are applied as given, with parameter substitution applied first.
 
 ```yaml
 apiVersion: templates.stakater.com/v1alpha1
@@ -71,23 +69,9 @@ resources:
             port: 5978
 ```
 
-### 2. Helm
+### Helm
 
-This method integrates Helm charts into the template, allowing you to leverage Helm's templating capabilities and package management.
-
-#### How It Works
-
-* The `Template` references a Helm chart.
-* Values for the Helm chart can be passed by the `values` field.
-* The Helm chart generates the necessary Kubernetes resources dynamically at runtime.
-
-#### Use Cases
-
-* Best for complex resource setups with interdependencies (e.g., a microservice with a Deployment, Service, Ingress, and ConfigMap).
-* Useful for resources requiring advanced templating logic or modular packaging.
-* Great for managing third-party tools or applications (e.g., deploying Prometheus, Keycloak, or databases).
-
-#### Example
+References a chart from a repository and renders it at deploy time. Values can be passed as a block through `values`, or individually through `setValues`.
 
 ```yaml
 apiVersion: templates.stakater.com/v1alpha1
@@ -118,45 +102,11 @@ resources:
       redisPort: 6379
 ```
 
-A brief explanation of the fields in the Helm section:
+`releaseName` defaults to the template name if omitted. Private repositories are supported by pointing `username` and `password` at keys in an existing Secret. Each entry in `setValues` maps to a `--set` argument, or `--set-string` when `forceString` is true.
 
-* `releaseName`: The name of the Helm release.
-* `chart`: The Helm chart details.
-    * `repository`: The Helm repository details.
-        * `name`: The name of the Helm repository.
-        * `version`: The version of the Helm chart.
-        * `repoUrl`: The URL of the Helm repository.
-    * `username`: A reference to the secret containing the username for the Helm repository in case the chart is in a private repository.
-        * `key`: The key in the secret containing the username.
-        * `name`: The name of the secret containing the username.
-        * `namespace`: The namespace of the secret containing the username.
-    * `password`: A reference to the secret containing the password for the Helm repository in case the chart is in a private repository.
-        * `key`: The key in the secret containing the password.
-        * `name`: The name of the secret containing the password.
-        * `namespace`: The namespace of the secret containing the password.
-* `setValues`: The values to set in the Helm chart.
-    * `name`: The name of the value.
-    * `value`: The value to set.
-    * `forceString`: Whether to use `--set` or `--set-string` when setting the value. Default is `false` (use `--set`).
-* `values`: The values file for the Helm chart.
+### GoTemplate
 
-### 3. GoTemplate
-
-This method uses inline Go templates to dynamically generate Kubernetes manifests. It leverages Go's [text/template](https://pkg.go.dev/text/template) syntax along with [Sprig functions](https://masterminds.github.io/sprig/) for string operations, date formatting, conditionals, arithmetic, and more.
-
-#### How It Works
-
-* The `gotemplate` section contains YAML written with Go template expressions such as `{{ .Name }}` or `{{ now | date "2006-01-02" }}`.
-* Template `parameters` are injected at runtime, and Sprig functions can be used to transform or compute values.
-* The rendered output must be valid Kubernetes YAML, which the operator then applies to the target namespaces.
-
-#### Use Cases
-
-* Ideal for dynamic resource generation without maintaining a full Helm chart.
-* Useful when you need lightweight templating with conditional or computed fields.
-* Suitable for resources that change based on tenant, namespace, or environment attributes.
-
-#### Example
+An inline Go template, using [text/template](https://pkg.go.dev/text/template) syntax with [Sprig functions](https://masterminds.github.io/sprig/) available. Template parameters are exposed as fields on the render context, so `${NAME}` in the other sources is written `{{ .NAME }}` here. The rendered output must be valid Kubernetes YAML.
 
 ```yaml
 apiVersion: templates.stakater.com/v1alpha1
@@ -182,20 +132,9 @@ resources:
       configVersion: "{{ now | date "2006-01-02" }}"
 ```
 
-### 4. Resource Mapping
+### Resource mapping
 
-This approach maps secrets and ConfigMaps from one tenant's namespace to another tenant's namespace, or within a tenant's namespace.
-
-#### How It Works
-
-* The template contains mappings to pre-existing resources (secrets and ConfigMaps only).
-
-#### Use Cases
-
-* Ideal for maintaining consistency across shared resources without duplicating definitions.
-* Best when resources already exist.
-
-#### Example
+Copies Secrets and ConfigMaps that already exist somewhere in the cluster into the target namespaces. Only these two kinds are supported. The operator watches the source resources, so an update to a source is propagated to the copies.
 
 ```yaml
 apiVersion: templates.stakater.com/v1alpha1
@@ -211,3 +150,69 @@ resources:
       - name: configmap-c1
         namespace: namespace-n2
 ```
+
+## Parameters
+
+Parameters let one template serve several namespaces or tenants. A template declares the parameters it accepts, and an instance supplies values for them.
+
+```yaml
+apiVersion: templates.stakater.com/v1alpha1
+kind: Template
+metadata:
+  name: app-config
+parameters:
+  - name: CIDR_IP
+    value: "172.17.0.0/16"
+  - name: REPLICAS
+    required: true
+    validation: "^[0-9]+$"
+```
+
+`value` is the default used when an instance does not supply one. A parameter marked `required` must be supplied by the instance. A `validation` pattern is a regular expression checked against the value the instance supplies.
+
+!!! note
+    An instance may only set parameters the template declares. Passing an undeclared name fails the deployment with `parameter <name> does not exist in template <template>`, which catches typos rather than letting them silently render as empty.
+
+### Resolution order
+
+A reference is resolved by taking the first match in this order:
+
+1. Predefined parameters, resolved from the target namespace.
+1. The value set on the instance.
+1. The default `value` on the template.
+1. No match, in which case the reference is left in the output verbatim as `${NAME}`.
+
+The last case is worth remembering when a rendered resource contains a literal `${SOMETHING}`: the name was never declared as a parameter.
+
+### Predefined parameters
+
+These are resolved by the operator from the target namespace, so they do not need to be declared. Names are matched case-insensitively.
+
+| Reference | Resolves to |
+| --- | --- |
+| `${NAMESPACE}` | Name of the namespace being rendered into |
+| `${TENANT}` | Name of the tenant owning that namespace |
+| `${namespace.metadata.labels.<key>}` | Value of the given label on the target namespace |
+| `${namespace.metadata.annotations.<key>}` | Value of the given annotation on the target namespace |
+
+`${TENANT}` requires Multi Tenant Operator, since it reads the tenant label the `Tenant` resource puts on the namespace. It fails if the namespace is not owned by a tenant. The label and annotation forms fail if the key is absent, rather than rendering an empty value.
+
+### Strings and expressions
+
+`${NAME}` substitutes into a string. `${{NAME}}` is an expression: the replacement is parsed as YAML, so the field receives a typed value.
+
+```yaml
+replicas: ${{REPLICA_COUNT}}     # renders as the number 3
+tier: "${TIER_NAME}"             # renders as the string "gold"
+```
+
+The distinction matters where Kubernetes expects a non-string. Writing `replicas: "${REPLICA_COUNT}"` produces a quoted string and the resource is rejected. Expression form applies only when the whole value is exactly `${{NAME}}`, so it cannot be used for part of a longer string.
+
+To emit a literal `${NAME}` without substitution, double the dollar sign:
+
+```yaml
+data:
+  shellSnippet: "echo $${HOME}"  # renders as: echo ${HOME}
+```
+
+This is needed for config files and scripts that use the same syntax for their own variables.

--- a/content/concepts/templates/template.md
+++ b/content/concepts/templates/template.md
@@ -216,3 +216,10 @@ data:
 ```
 
 This is needed for config files and scripts that use the same syntax for their own variables.
+
+## Related guides
+
+- [Distributing Resources in Namespaces](../../guides/templates/deploying-templates.md)
+- [Using Templates with Default Parameters](../../guides/templates/template-default-params.md)
+- [Deploying Private Helm Chart to Multiple Namespaces](../../guides/templates/deploying-private-helm-charts.md)
+- [Distributing Secrets Using Sealed Secrets Template](../../guides/templates/distributing-secrets-using-sealed-secret-template.md)

--- a/content/concepts/terminology.md
+++ b/content/concepts/terminology.md
@@ -1,15 +1,39 @@
-# Concepts
+# Terminology
 
-Here are the key concepts of Template Operator:
+Terms used throughout the Template Operator documentation.
 
 ## Template
 
-A **Template** is a reusable blueprint in Template Operator that defines configurations for Kubernetes resources. It supports raw manifests, gotemplate based inline manifests, Helm charts, or resource mappings, enabling standardization and automation across multiple tenants.
+A cluster-scoped resource holding the definitions to distribute. A `Template` describes what to create, not where to create it, and on its own it deploys nothing. Definitions come from one of four sources: raw `manifests`, a `helm` chart, an inline `gotemplate`, or `resourceMappings` that copy existing Secrets and ConfigMaps.
 
-## Template Instance (TI)
+## Instance
 
-A **Template Instance** is a concrete implementation of a **Template**, created with specific parameters tailored for a particular tenant or use case. It generates actual Kubernetes resources based on the defined template.
+A resource that applies a `Template` somewhere. Template Operator has two: `TemplateInstance` for a single namespace, and `ClusterTemplateInstance` for every namespace matching a label selector. Both reference a template by name in `spec.template`.
 
-## Cluster Template Instance (CTI)
+## Target namespace
 
-A **Cluster Template Instance** works on a particular set of namespaces based on the mentioned labels, taking **Template** as a reference for the resources to be deployed. It simplifies managing multiple interdependent resources for complex tenant setups.
+The namespace an instance renders into. For a `TemplateInstance` this is its own namespace. For a `ClusterTemplateInstance` there is one target namespace per selector match, and the template is rendered separately for each, so parameters resolved from namespace metadata can differ between them.
+
+## Parameter
+
+A named value substituted into a template at render time, referenced as `${NAME}`. A `Template` declares its parameters and may give each a default, mark it `required`, or constrain it with a `validation` regular expression. Instances supply values for those parameters. An instance cannot introduce a parameter the template does not declare.
+
+## Predefined parameter
+
+A parameter resolved by the operator from the target namespace rather than declared in the template, such as `${NAMESPACE}` or `${TENANT}`. See [Template](templates/template.md#parameters) for the full list.
+
+## Expression parameter
+
+A substitution written `${{NAME}}` instead of `${NAME}`. The replacement is parsed as YAML, so the field receives a number, boolean, list, or map rather than a string. See [Template](templates/template.md#strings-and-expressions).
+
+## Resource mapping
+
+A template that copies existing Secrets and ConfigMaps from a source namespace into target namespaces, instead of defining new resources. The operator watches the sources, so later changes to them reach the copies.
+
+## Sync
+
+The `spec.sync` field on an instance. When false, the instance renders once and is then left alone, even if the template changes. When true, the operator keeps the deployed resources aligned with the template. See [TemplateInstance](templates/template-instance.md#sync).
+
+## TemplateGroupInstance
+
+The predecessor of `ClusterTemplateInstance`, part of the legacy `tenantoperator.stakater.com/v1alpha1` API group that Template Operator still serves for migration. New work should use `ClusterTemplateInstance`.


### PR DESCRIPTION
# Add Concepts content for Template Operator

Fleshes out the Concepts section so Template Operator matches the shared docs structure (the same layout MTO and the other operators use) and its concept pages can be merged cleanly into the MTO site.

This adds the per resource concept pages under Concepts (Template, TemplateInstance, ClusterTemplateInstance), expands the Architecture and Terminology pages, and appends a "related guides" list at the end of each concept page so readers can jump from a concept to its how to guides. Also fixes markdown linting.

No nav or tooling changes, purely content. Example: the Templates concept group now reads as

```text
Concepts
  Templates
    Template
    Template Instance
    Cluster Template Instance
```
